### PR TITLE
Add PPTX to YAML converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # pptmaker
-AI based PPT Maker
+
+A tool for converting PowerPoint presentations into a YAML representation.
+
+This project uses `python-pptx` to parse PPTX files and `openai` to generate
+textual descriptions for images found within slides. Tables are converted to
+Markdown and all text content is preserved. The resulting YAML file contains a
+list of slides with their titles, texts, images and tables.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python -m pptmaker input.pptx output.yaml
+```
+
+The OpenAI API key must be provided via the `OPENAI_API_KEY` environment
+variable if image descriptions are required.

--- a/pptmaker/__main__.py
+++ b/pptmaker/__main__.py
@@ -1,0 +1,19 @@
+import argparse
+import sys
+from .converter import pptx_to_yaml
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Convert PPTX to YAML")
+    parser.add_argument("pptx", help="Path to PPTX file")
+    parser.add_argument("output", help="Path to output YAML file")
+    args = parser.parse_args(argv)
+
+    yaml_text = pptx_to_yaml(args.pptx)
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(yaml_text)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pptmaker/converter.py
+++ b/pptmaker/converter.py
@@ -1,0 +1,123 @@
+import base64
+import io
+import os
+from dataclasses import dataclass, field
+from typing import List, Dict, Any
+
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+import yaml
+
+try:
+    import openai
+except ImportError:  # pragma: no cover
+    openai = None
+
+@dataclass
+class SlideImage:
+    description: str
+    filename: str | None = None
+    data: str | None = None  # base64 encoded image data
+
+@dataclass
+class SlideTable:
+    markdown: str
+
+@dataclass
+class SlideContent:
+    title: str | None
+    texts: List[str] = field(default_factory=list)
+    images: List[SlideImage] = field(default_factory=list)
+    tables: List[SlideTable] = field(default_factory=list)
+
+
+def describe_image(image_bytes: bytes) -> str:
+    """Use OpenAI to generate an alt text description for an image."""
+    if openai is None:
+        raise RuntimeError("openai package is required for image description")
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+    openai.api_key = api_key
+    # Using GPT-4 vision or similar; here we just send a prompt with base64 image
+    encoded = base64.b64encode(image_bytes).decode("ascii")
+    prompt = (
+        "Describe the following image from a PowerPoint slide in one or two sentences."
+    )
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-4-vision-preview",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": prompt,
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/png;base64,{encoded}",
+                            },
+                        },
+                    ],
+                }
+            ],
+            max_tokens=60,
+        )
+        return response.choices[0].message.content.strip()
+    except Exception as exc:  # pragma: no cover - network related
+        raise RuntimeError(f"Failed to get image description: {exc}")
+
+
+def convert_table_to_markdown(table) -> str:
+    """Convert a python-pptx table shape to markdown."""
+    rows = []
+    for row in table.rows:
+        cells = [cell.text for cell in row.cells]
+        rows.append("| " + " | ".join(cells) + " |")
+    if not rows:
+        return ""
+    header = rows[0]
+    separator = "| " + " | ".join(["---" for _ in table.columns]) + " |"
+    return "\n".join([header, separator] + rows[1:])
+
+
+def extract_slide_content(slide) -> SlideContent:
+    title = None
+    if slide.shapes.title:
+        title = slide.shapes.title.text
+    content = SlideContent(title=title)
+    for shape in slide.shapes:
+        if not shape.has_text_frame and shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+            # Extract image
+            image_bytes = shape.image.blob
+            description = describe_image(image_bytes)
+            encoded = base64.b64encode(image_bytes).decode("ascii")
+            content.images.append(
+                SlideImage(description=description, data=encoded)
+            )
+        elif shape.has_text_frame:
+            text = shape.text_frame.text
+            if text:
+                content.texts.append(text)
+        elif shape.shape_type == MSO_SHAPE_TYPE.TABLE:
+            md = convert_table_to_markdown(shape.table)
+            content.tables.append(SlideTable(markdown=md))
+    return content
+
+
+def pptx_to_yaml(path: str) -> str:
+    prs = Presentation(path)
+    slides: List[Dict[str, Any]] = []
+    for slide in prs.slides:
+        content = extract_slide_content(slide)
+        slides.append({
+            "title": content.title,
+            "texts": content.texts,
+            "images": [image.__dict__ for image in content.images],
+            "tables": [table.__dict__ for table in content.tables],
+        })
+    return yaml.safe_dump({"slides": slides}, sort_keys=False, allow_unicode=True)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-pptx
+PyYAML
+openai
+pytest

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,37 @@
+import yaml
+from pptx import Presentation
+from pptx.util import Inches
+import pptmaker.converter as conv
+
+
+def create_sample_pptx(path):
+    prs = Presentation()
+    slide_layout = prs.slide_layouts[1]
+    slide = prs.slides.add_slide(slide_layout)
+    slide.shapes.title.text = "Title"
+    tf = slide.shapes.placeholders[1].text_frame
+    tf.text = "First bullet"
+    p = tf.add_paragraph()
+    p.text = "Second bullet"
+    rows, cols = 2, 2
+    left = top = Inches(1)
+    width = height = Inches(2)
+    table_shape = slide.shapes.add_table(rows, cols, left, top, width, height)
+    table = table_shape.table
+    table.cell(0, 0).text = "H1"
+    table.cell(0, 1).text = "H2"
+    table.cell(1, 0).text = "A"
+    table.cell(1, 1).text = "B"
+    prs.save(path)
+
+
+def test_pptx_to_yaml(tmp_path, monkeypatch):
+    pptx_path = tmp_path / "sample.pptx"
+    create_sample_pptx(pptx_path)
+    monkeypatch.setattr(conv, "describe_image", lambda x: "desc")
+    yaml_text = conv.pptx_to_yaml(str(pptx_path))
+    data = yaml.safe_load(yaml_text)
+    slide = data["slides"][0]
+    assert slide["title"] == "Title"
+    assert "First bullet" in slide["texts"][0]
+    assert "| H1 | H2 |" in slide["tables"][0]["markdown"]


### PR DESCRIPTION
## Summary
- implement a converter using python-pptx and OpenAI to turn PPTX slides into a YAML file
- provide a CLI entry point
- document usage and installation in README
- add sample tests and requirements list

## Testing
- `pip install -q -r requirements.txt` *(fails: no matching distribution)*
- `pytest -q` *(fails: command not found)*